### PR TITLE
Devt (#990)

### DIFF
--- a/.github/workflows/convert_to_fluidnc.yml
+++ b/.github/workflows/convert_to_fluidnc.yml
@@ -1,4 +1,4 @@
-name: FluidNC Release Builder
+name: FluidNC Configuration Generator
 
 on:
   workflow_dispatch:

--- a/.github/workflows/convert_to_fluidnc.yml
+++ b/.github/workflows/convert_to_fluidnc.yml
@@ -1,0 +1,39 @@
+name: FluidNC Release Builder
+
+on:
+  workflow_dispatch:
+    inputs:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Cache PlatformIO
+      uses: actions/cache@v2
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+    - name: Set up Python
+      uses: actions/setup-python@v2
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade platformio
+    - name: Build
+      run: |
+        python convert-machine.py User.h
+    - name: Upload mac bundle
+      uses: actions/upload-artifact@v2
+      with:
+        name: FluidNC_Config
+        path: yaml/User*

--- a/Grbl_Esp32/src/Grbl.h
+++ b/Grbl_Esp32/src/Grbl.h
@@ -22,7 +22,7 @@
 
 // Grbl versioning system
 const char* const GRBL_VERSION       = "1.3a";
-const char* const GRBL_VERSION_BUILD = "20211028";
+const char* const GRBL_VERSION_BUILD = "20211103";
 
 //#include <sdkconfig.h>
 #include <Arduino.h>

--- a/Grbl_Esp32/src/Machines/6_pack_stepstick_v1.h
+++ b/Grbl_Esp32/src/Machines/6_pack_stepstick_v1.h
@@ -122,6 +122,9 @@ Socket #5
 #define Z_LIMIT_PIN             GPIO_NUM_35
 #define PROBE_PIN               GPIO_NUM_34
 
+#define DEFAULT_INVERT_LIMIT_PINS       0
+#define DEFAULT_INVERT_PROBE_PIN        0
+
 
 // 5V output CNC module in socket #3
 // https://github.com/bdring/6-Pack_CNC_Controller/wiki/4x-5V-Buffered-Output-Module
@@ -133,3 +136,5 @@ Socket #5
 
 // === Default settings
 #define DEFAULT_STEP_PULSE_MICROSECONDS I2S_OUT_USEC_PER_PULSE
+
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 # Grbl (CNC Controller) For ESP32
 
-<img src="https://user-images.githubusercontent.com/189677/93836185-74c27500-fc47-11ea-8bed-5d419974c196.jpg" width="600">
+<img src="https://github.com/bdring/FluidNC/wiki/images/hardware/20200711_120633.png" width="600">
+
+## Get the Next Generation!
+
+The next generation of Grbl_ESP32 was such a massive upgrade we decided to change the name. It is called **FluidNC** and is [available here](https://github.com/bdring/FluidNC). Please check it out and give us a star. It is compatible with all Grbl_ESP32 hardware.
+
+This version is only being maintained with existing features. All new features are targeted at FluidNC.
 
 ### Project Overview
 


### PR DESCRIPTION
* changing  to EXTENDED type from GRBL type to prevent sender issues when running 1585

* Oled2 (#834)

* WIP

* WIP

* Update platformio.ini

* WIP

* Cleanup

* Update platformio.ini

* Turn off soft limits with max travel (#836)

https://github.com/bdring/Grbl_Esp32/issues/831

* Yalang YL620 VFD (#838)

* New SpindleType YL620

Files for new SpindleType Yalang 620. So far the contents are a duplicate of H2ASpindle.h and H2ASpindle.cpp

* Added register documentation and implemented read and write data packets

* Some fixes, mostly regarding RX packet length

* OLED and Other Updates (#844)

* publish

* Updates - CoreXY and OLED

- Moved position calculation out of report_realtime_status(...) so other functions can access it.
- Added a function to check if a limit switch is defined
- CoreXY fixed bug in forward kinematics when midtbot is used.
- Modified OLED display.

* Cleanup for PR

* Delete midtbot_x2.h

* Incorporated PR 846

- Some OLED cleanup
- verified correct forward kinematics on MidTbot

* Pio down rev (#850)

* Update platformio.ini

* Update Grbl.h

* Use local UART driver not HardwareSerial (#857)

* Use local UART driver not HardwareSerial

The HardwareSerial driver is broken in Arduino framework versions
1.0.5 and 1.0.6 .  https://github.com/espressif/arduino-esp32/issues/5005
Instead of waiting for a fix, I wrote a very simple UART driver that
does exactly what we need with no unnecessary bells and whistles to
cause problems.

* Added missing files, changed method signatures

The methods implemented by the UART class now
have the same signatures as the HardwareSerial
class, so it will be easy to switch back if we
need to.

* Incorporated suggestions from Stefan

* Fixed TX_IDLE_NUM bug reported by mstrens

* Quick test for Bf: problem

This is not the final solution.

* Fixed stupid typo in last commit

* Another test - check for client_buffer space

* Use the esp-idf uart driver

You can revert to the direct driver for testing by
defining DIRECT_UART

* Uart class now supports VFD and TMC

* data bits, stop bits, parity as enum classes

The constants for data bits, stop bits, and parity
were changed to enum classes so the compiler can
check for argument order mismatches.

* Set half duplex after uart init

* Init TMC UART only once

* rx/tx pin order mixup, missing _uart_started

* Test: use Arduino Serial

This reverts to the Arduino serial driver for
UI communication, leaving the VFS comms on the
Uart class on top of the esp_idf UART driver.

You can switch back and forth with the
   define REVERT_TO_SERIAL
line in Serial.cpp

* REVERT_TO_ARDUINO_SERIAL off by default

* Added debug messages

* Update Grbl.h

* Update platformio.ini

Co-authored-by: bdring <barton.dring@gmail.com>

* Fixed spindle sync for all VFD spindles (#868)

* Implemented H2A spindle sync fix. Untested.

* Changed the spindle sync fix to be in the VFD code.

* Update Grbl.h

Co-authored-by: Stefan de Bruijn <stefan@nubilosoft.com>
Co-authored-by: bdring <barton.dring@gmail.com>

* New jog fix (#872)

* Applied 741 to new Devt

* Make kinematics routines weak

to eliminate ifdefs

* Fixed warning

* Update build date

Co-authored-by: bdring <barton.dring@gmail.com>

* need to override set_rpm

* trying set_rpm override

* it turns on!

* start/stop and set speed all working

* cleanup

* fixing machine.h

* fix .gitignore *&vi .gitignore  didn't work anyway

* forgot to get rid of hard coded max_freq, fixed now

* changed 'speed' to 'freq'

* reverting platformio.ini

* minor readme update

* removed debug msg

* Big kinematics cleanup (#875)

* Applied 741 to new Devt

* Make kinematics routines weak

to eliminate ifdefs

* Fixed warning

* Big kinematics cleanup

* Cleanup

* no isCancelled arg for jog_execute; return it instead

* WIP

* Made OLED compliant with new kinematics

* Added system_get_mpos

* system_get_mpos() returns float*

* WIP

* Cleanup after testing

- Had MPos and WPos text on OLED backwards.
- Added my cartesian test def
- Will remove test defs before merging to devt.

* Cleanup of remaining user optional code.

* Fixed delta kinematics loop ending early.

* Account for jog cancel in saved motor positions

* Update Grbl.h

Co-authored-by: bdring <barton.dring@gmail.com>

* Add the Root 4 Lite CNC machine to the Machines folder (#886)

* update for the Root 4 Lite

* Return machine.h to use test_drive.hy

* Removed some machine definitions

Co-authored-by: bdring <barton.dring@gmail.com>

* YL620_Fix (#941)

* YL620_Fix

Fix per ... https://github.com/bdring/Grbl_Esp32/issues/926#issuecomment-867885248
Added CNC_xPro machine def

* Update Grbl.h

* Delete CNC_xPRO_V5_XYYZ_PWM_NO.h

* fixes for RPM

* note

* fixed rx length

* fix smell and update readme

* clang format

* trying to fix newlines

* trying to fix newlines part 2

* fix cast issue

* fixed spinup spindown swap.

* Core xy soft limits (#960)

* Soft limit fix

* Update Grbl.h

* Increase serial task stack size (#970)

* Increase stack size

- Also changed defaults of trinamic motor currents

* Update Grbl.h

* 5160 class fix (#981)

* Fixed class inheritance

* Update date

* Update Machine.h

* Update Grbl.h

* Improved an example and added link to FluidNC

* Update Grbl.h

Co-authored-by: me <me_xeon_wsl_ubuntu18@brng.us>
Co-authored-by: Mitch Bradley <wmb@firmworks.com>
Co-authored-by: marcosprojects <marco1601@web.de>
Co-authored-by: Stefan de Bruijn <atlaste@users.noreply.github.com>
Co-authored-by: Stefan de Bruijn <stefan@nubilosoft.com>
Co-authored-by: Pete <rcnc3d@gmail.com>
Co-authored-by: Jesse Schoch <schoch@gmail.com>